### PR TITLE
Add database_excludes variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following environment variables are supported (incl. example values):
 - `DIR_DATE_PATTERN:` "%Y%m%d"
 - `FULL_BACKUP_DATE_FORMAT:` "%a"
 - `FULL_BACKUP_DATE_RESULT:` "Sun"
+- `DATABASES_EXCLUDE:` "example example1.table1"
 - `ROTATION1_DAYS:` 6
 - `ROTATION1_DATE_FORMAT:` "%a"
 - `ROTATION1_DATE_RESULT:` "Sun"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -42,13 +42,18 @@ if [ ${compress_threads} -gt 0 ]; then
     echo " with compression enabled"
 fi
 
+if [ ! -z "${databases_exclude}" ]; then
+    OPT="--databases-exclude=\"${databases_exclude}\" ${OPT}"
+    echo " with databases exclude"
+fi
+
 command="${xtrabackup} --backup \
      --user=${db_user} \
-     --password=${db_password} \
+     --password=\"${db_password}\" \
      --host=${db_host} \
      --port=${db_port} \
      ${OPT}";
 
-$command
+eval $command
 
 echo "$(${log_prefix}) INFO: backup process finished";

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -8,6 +8,8 @@ dir_date_pattern=${DIR_DATE_PATTERN:-"%Y%m%d"}
 full_backup_date_format=${FULL_BACKUP_DATE_FORMAT:-"%a"}
 full_backup_date_result=${FULL_BACKUP_DATE_RESULT:-"Sun"}
 
+databases_exclude="${DATABASES_EXCLUDE}"
+
 db_user=${MYSQL_USER:-"root"}
 db_password="${MYSQL_PASSWORD}"
 db_host=${MYSQL_HOST:-"db"}


### PR DESCRIPTION
I was needed to exclude some databases from the backup and mariabackup handle it using --database-excludes options.

I did the following changes :

   - Use eval to execute backup command to avoid issues with spaces
   - Fix issue with space in password
   - Add databases_exclude in config